### PR TITLE
lanceur windows : meilleure gestion des paramètres

### DIFF
--- a/launcher/c2e.cmd
+++ b/launcher/c2e.cmd
@@ -19,4 +19,4 @@ set "PATH=%PATH%;C:\Program Files\Java\jre10\bin\"
 set "PATH=%PATH%;C:\Program Files\Java\jre\bin\"
 set "PATH=%PATH%;%OPATH%"
 
-java.exe -jar -Xms32m -Xmx512m -Dfile.encoding=UTF-8 "c2e.jar" %1 %2 %3 %4 %5 %6 %7 %8 %9
+java.exe -jar -Xms32m -Xmx512m -Dfile.encoding=UTF-8 "c2e.jar" %*


### PR DESCRIPTION
Bonjour,

En fait je trouvais ça limitant de ne pouvoir passer que 9 arguments, du coup j'ai un peu adapté le script pour qu'il soit plus proche de celui pour linux.

Pour tester : 
` .\c2e.cmd a b c d e f g h i j k l m n o p q r s t u v w x y z`

